### PR TITLE
Switch to lightweight critical section

### DIFF
--- a/Native/PerformanceMonitor/inc/PerformanceMonitor.h
+++ b/Native/PerformanceMonitor/inc/PerformanceMonitor.h
@@ -24,7 +24,8 @@
 class PerformanceMonitorHttpModule : public CHttpModule
 {
 public:
-	static HANDLE		g_mutex;		// to protect reading and writing static variables between threads (ie. different http requests/responses)
+	// to protect reading and writing static variables between threads (ie. different http requests/responses)
+	static CRITICAL_SECTION g_criticalSection;
 
 	HighResolutionTimer _requestTimer;
 	HighResolutionTimer _handlerTimer;
@@ -44,10 +45,14 @@ public:
 public:
 	// Constructor
 	PerformanceMonitorHttpModule()
-	{}
+	{
+		InitializeCriticalSection(&g_criticalSection);
+	}
 
 	~PerformanceMonitorHttpModule()
-	{}
+	{
+		DeleteCriticalSection(&g_criticalSection);
+	}
 
 
 	// CHttpModule methods (events)

--- a/Native/PerformanceMonitor/inc/precomp.h
+++ b/Native/PerformanceMonitor/inc/precomp.h
@@ -13,6 +13,7 @@
 
 #include <tchar.h>
 #include <stdio.h>
+#include <atlstr.h>
 
 #include <sal.h>
 //  IIS7 Server API header file

--- a/Native/PerformanceMonitorUnitTest/PerformanceMonitorUnitTest.vcxproj
+++ b/Native/PerformanceMonitorUnitTest/PerformanceMonitorUnitTest.vcxproj
@@ -100,6 +100,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">


### PR DESCRIPTION
Switch to using lightweight critical sections because we don't need to syncronize between processes.